### PR TITLE
feat: migrate to new WhatPulse public API with Bearer authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 *.iml
+__pycache__

--- a/README.md
+++ b/README.md
@@ -22,6 +22,33 @@ This is a custom component for Home Assistant (https://home-assistant.io) that p
 - Configure with config below.
 - Restart Home Assistant.
 
+## ⚠️ Breaking Changes in v3.0
+
+**Version 3.0 introduces breaking changes for the public API configuration:**
+
+The WhatPulse public API has been updated to use authentication tokens. You'll need to:
+
+1. **Get your API token**: Visit your WhatPulse dashboard to generate an API token (https://whatpulse.org/dashboard/my/api)
+2. **Update your configuration**: Add `api_token`
+
+**Old configuration:**
+```yaml
+sensor:
+  - platform: whatpulse
+    username: your_username
+    api_type: public
+```
+
+**New configuration (v3.0+):**
+```yaml
+sensor:
+  - platform: whatpulse
+    username: your_username    # Either username or userid required
+    userid: your_user_id       # Either username or userid required
+    api_token: your_api_token
+    api_type: public
+```
+
 ## Configuration
 
 ### Basic Configuration
@@ -32,8 +59,9 @@ To use this component in your installation, add the following to your HA `config
 # Example configuration.yaml entry with public API
 sensor:
   - platform: whatpulse
-    userid: your_user_id  # preferred over username
-    api_type: public  # Options: public, client, both
+    userid: your_user_id       # Either username or userid required
+    api_token: your_api_token  # Required for public API
+    api_type: public           # Options: public, client, both
     sensors:
       - Keys
       - Clicks
@@ -49,9 +77,10 @@ For more advanced usage including client API and buttons:
 # Full configuration example
 sensor:
   - platform: whatpulse
-    userid: "12345"          # Preferred over username
-    username: an_user_name   # Used if userid is not provided
-    api_type: client         # Options: public, client, both
+    userid: "12345"          # Either username or userid required for public API
+    api_token: "your_bearer_token"  # Required for public API
+    username: an_user_name   # Alternative to userid
+    api_type: both           # Options: public, client, both
     client_api_url: "http://192.168.1.100:3490"  # WhatPulse client API URL
     sensors:
       - Keys
@@ -74,10 +103,13 @@ button:
 
 #### Sensor Platform
 - username (Optional): The username for the WhatPulse account
-- userid (Optional, preferred): The numeric user ID for the WhatPulse account
+- userid (Optional): The numeric user ID for the WhatPulse account (alternative to username)
+- api_token (Required for public API): Your WhatPulse API bearer token
 - api_type (Optional, default: public): The API type to use - public, client, or both
 - client_api_url (Optional, default: http://localhost:3490): URL for the client API
 - sensors (Optional): List of sensors to enable (see Available Sensors below)
+
+**Note**: For public API, you must provide either `username` or `userid` along with `api_token`.
 
 #### Button Platform
 - client_api_url (Required): URL for the client API
@@ -93,33 +125,33 @@ button:
 - DownloadMB: Total download in megabytes
 - UploadMB: Total upload in megabytes
 - UptimeSeconds: Total computer uptime in seconds
-- UptimeShort: Short formatted uptime string
-- UptimeLong: Long formatted uptime string
-- DistanceInMiles: Mouse cursor movement distance
-- Pulses: Number of pulses sent
+- UptimeShort: Short formatted uptime string (e.g., "6y 46w 1d 17h 44m")
+- UptimeLong: Long formatted uptime string (e.g., "6 years, 46 weeks, 1 day, 17 hours, 44 minutes, 51 seconds")
+- DistanceInMiles: Mouse cursor movement distance in miles
+- Pulses: Number of pulses sent to WhatPulse
 - AvKeysPerPulse: Average keys per pulse
 - AvClicksPerPulse: Average clicks per pulse
-- AvKPS: Average keys per second
-- AvCPS: Average clicks per second
-- RankKeys: Ranking position for keys
-- RankClicks: Ranking position for clicks
-- RankDownload: Ranking position for download
-- RankUpload: Ranking position for upload
-- RankUptime: Ranking position for uptime
-- RankScrolls: Ranking position for scrolls
-- RankDistance: Ranking position for mouse distance
+- AvKPS: Average keys per second (calculated from total keys / uptime)
+- AvCPS: Average clicks per second (calculated from total clicks / uptime)
+- RankKeys: Global ranking position for keys
+- RankClicks: Global ranking position for clicks
+- RankDownload: Global ranking position for download
+- RankUpload: Global ranking position for upload
+- RankUptime: Global ranking position for uptime
+- RankScrolls: Global ranking position for scrolls
+- RankDistance: Global ranking position for mouse distance
 
-**Client API Sensors**
+**Client API Sensors** *(Requires WhatPulse client with API enabled)*
 - RealtimeKeys: Current keys per second
 - RealtimeClicks: Current clicks per second
-- RealtimeDownload: Current download speed
-- RealtimeUpload: Current upload speed
-- UnpulsedKeys: Keys since last pulse
-- UnpulsedClicks: Clicks since last pulse
-- UnpulsedScrolls: Scrolls since last pulse
-- UnpulsedDownload: Download since last pulse
-- UnpulsedUpload: Upload since last pulse
-- UnpulsedUptime: Uptime since last pulse
+- RealtimeDownload: Current download speed (formatted)
+- RealtimeUpload: Current upload speed (formatted)
+- UnpulsedKeys: Keys pressed since last pulse
+- UnpulsedClicks: Clicks made since last pulse
+- UnpulsedScrolls: Scrolls made since last pulse
+- UnpulsedDownload: Bytes downloaded since last pulse
+- UnpulsedUpload: Bytes uploaded since last pulse
+- UnpulsedUptime: Uptime seconds since last pulse
 
 #### Button Controls
 When the client API is enabled, you'll have access to these buttons:

--- a/custom_components/whatpulse/const.py
+++ b/custom_components/whatpulse/const.py
@@ -3,7 +3,7 @@
 from datetime import timedelta
 
 # API URLs
-PUBLIC_API_URL = "https://api.whatpulse.org/user.php?"
+PUBLIC_API_URL = "https://whatpulse.org/api/v1/users/"  # New API URL
 DEFAULT_CLIENT_API_URL = "http://localhost:3490"  # Default client API URL
 
 # Refresh rates
@@ -15,6 +15,7 @@ MIN_TIME_BETWEEN_UPDATES_CLIENT = timedelta(seconds=CLIENT_REFRESH_RATE)
 # Configuration constants
 DOMAIN = "whatpulse"
 CONF_USERID = "userid"
+CONF_API_TOKEN = "api_token"  # New API token configuration
 CONF_API_TYPE = "api_type"
 CONF_SENSORS = "sensors"
 CONF_CLIENT_API_URL = "client_api_url"

--- a/custom_components/whatpulse/manifest.json
+++ b/custom_components/whatpulse/manifest.json
@@ -9,5 +9,5 @@
     "@smitmartijn",
     "@whatpulse"
   ],
-  "version": "2.0"
+  "version": "3.0.0"
 }

--- a/custom_components/whatpulse/sensor.py
+++ b/custom_components/whatpulse/sensor.py
@@ -19,6 +19,7 @@ from .const import (
     API_TYPE_CLIENT,
     API_TYPE_PUBLIC,
     CONF_API_TYPE,
+    CONF_API_TOKEN,
     CONF_CLIENT_API_URL,
     CONF_SENSORS,
     CONF_USERID,
@@ -39,6 +40,7 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_USERNAME): cv.string,
     vol.Optional(CONF_USERID): cv.string,
+    vol.Optional(CONF_API_TOKEN): cv.string,
     vol.Optional(CONF_API_TYPE, default=DEFAULT_API_TYPE): vol.In(
         [API_TYPE_PUBLIC, API_TYPE_CLIENT, API_TYPE_BOTH]
     ),
@@ -52,17 +54,22 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the WhatPulse sensor platform."""
     username = config.get(CONF_USERNAME)
     userid = config.get(CONF_USERID)
+    api_token = config.get(CONF_API_TOKEN)
     api_type = config.get(CONF_API_TYPE)
     client_api_url = config.get(CONF_CLIENT_API_URL)
     sensor_types = config.get(CONF_SENSORS)
 
-    # Require username or userid only for public API
-    if api_type in [API_TYPE_PUBLIC, API_TYPE_BOTH] and not (username or userid):
-        _LOGGER.error("Either username or userid must be provided when using public API")
-        return False
+    # Require username or userid and api_token for public API
+    if api_type in [API_TYPE_PUBLIC, API_TYPE_BOTH]:
+        if not (username or userid):
+            _LOGGER.error("Either username or userid must be provided when using public API")
+            return False
+        if not api_token:
+            _LOGGER.error("API token must be provided when using public API")
+            return False
 
     # Initialize API based on configuration
-    api = WhatPulseAPI(username, userid, api_type, client_api_url)
+    api = WhatPulseAPI(username, userid, api_token, api_type, client_api_url)
 
     entities = []
     for sensor_type in sensor_types:
@@ -90,10 +97,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class WhatPulseAPI:
     """Class to handle WhatPulse API calls."""
 
-    def __init__(self, username=None, userid=None, api_type=DEFAULT_API_TYPE, client_api_url=DEFAULT_CLIENT_API_URL):
+    def __init__(self, username=None, userid=None, api_token=None, api_type=DEFAULT_API_TYPE, client_api_url=DEFAULT_CLIENT_API_URL):
         """Initialize the API."""
         self._username = username
         self._userid = userid
+        self._api_token = api_token
         self._api_type = api_type
         self._client_api_url = client_api_url
         self._data = {}
@@ -140,29 +148,192 @@ class WhatPulseAPI:
 
     def _request_update_public(self):
         """Request update from public WhatPulse API."""
-        # Build the URL based on what we have (userid preferred)
-        url = PUBLIC_API_URL
-
-        if self._userid:
-            url += f"userid={self._userid}&format=json"
-        elif self._username:
-            url += f"user={self._username}&format=json"
-        else:
+        if not (self._username or self._userid):
             _LOGGER.error("No username or userid provided for WhatPulse public API")
             return False
 
+        if not self._api_token:
+            _LOGGER.error("No API token provided for WhatPulse public API")
+            return False
+
+        # Use userid if available, otherwise use username
+        identifier = self._userid if self._userid else self._username
+        url = f"{PUBLIC_API_URL}{identifier}"
+        headers = {
+            "Authorization": f"Bearer {self._api_token}",
+            "Accept": "application/json",
+        }
+
         try:
-            response = requests.get(url, timeout=10)
+            response = requests.get(url, headers=headers, timeout=10)
 
             if response.status_code != 200:
-                _LOGGER.error(f"Unable to perform public API request: {response.content}")
+                _LOGGER.error(f"Unable to perform public API request: {response.status_code} - {response.content}")
                 return False
 
-            return response.json()
+            data = response.json()
+
+            # Convert new API format to old API format for backward compatibility, not to break existing sensor configurations
+            if "user" in data:
+                return self._convert_new_api_format(data["user"])
+            else:
+                _LOGGER.error("Invalid API response format")
+                return False
 
         except Exception as ex:
             _LOGGER.error(f"Error fetching WhatPulse public API data: {ex}")
             return False
+
+    def _convert_new_api_format(self, user_data):
+        """Convert new API format to old API format for backward compatibility."""
+        try:
+            # Map the new API structure to the old API structure
+            converted_data = {
+                "UserID": str(user_data["id"]),
+                "AccountName": user_data["username"],
+                "DateJoined": user_data["date_joined"][:10],
+                "LastPulse": user_data["last_pulse_date"][:19].replace("T", " "),
+                "Pulses": str(user_data["pulses"]),
+                # Map totals
+                "Keys": str(user_data["totals"]["keys"]),
+                "Clicks": str(user_data["totals"]["clicks"]),
+                "Scrolls": str(user_data["totals"]["scrolls"]),
+                "DistanceInMiles": str(user_data["totals"]["distance_miles"]),
+                # Add both raw MB values AND formatted values
+                "DownloadMB": user_data["totals"]["download_mb"],
+                "UploadMB": user_data["totals"]["upload_mb"],
+                "Download": self._format_bytes(user_data["totals"]["download_mb"] * 1024 * 1024),
+                "Upload": self._format_bytes(user_data["totals"]["upload_mb"] * 1024 * 1024),
+                "UptimeSeconds": str(user_data["totals"]["uptime_seconds"]),
+                "UptimeShort": self._format_uptime_short(user_data["totals"]["uptime_seconds"]),
+                "UptimeLong": self._format_uptime_long(user_data["totals"]["uptime_seconds"]),
+                # Calculate additional values that are missing from new API
+                "AvKeysPerPulse": str(round(user_data["totals"]["keys"] / user_data["pulses"], 2)) if user_data["pulses"] > 0 else "0",
+                "AvClicksPerPulse": str(round(user_data["totals"]["clicks"] / user_data["pulses"], 2)) if user_data["pulses"] > 0 else "0",
+                # Calculate average per second values based on uptime
+                "AvKPS": str(round(user_data["totals"]["keys"] / user_data["totals"]["uptime_seconds"], 4)) if user_data["totals"]["uptime_seconds"] > 0 else "0",
+                "AvCPS": str(round(user_data["totals"]["clicks"] / user_data["totals"]["uptime_seconds"], 4)) if user_data["totals"]["uptime_seconds"] > 0 else "0",
+                # Map ranks
+                "Ranks": {
+                    "Keys": str(user_data["ranks"]["keys"]),
+                    "Clicks": str(user_data["ranks"]["clicks"]),
+                    "Download": str(user_data["ranks"]["download"]),
+                    "Upload": str(user_data["ranks"]["upload"]),
+                    "Uptime": str(user_data["ranks"]["uptime"]),
+                    "Scrolls": str(user_data["ranks"]["scrolls"]),
+                    "Distance": str(user_data["ranks"]["distance"]),
+                }
+            }
+
+            # Add team information if available
+            if "team" in user_data and user_data["team"]:
+                team = user_data["team"]
+                converted_data["Team"] = {
+                    "TeamID": str(team["id"]),
+                    "Name": team["name"],
+                    "Members": str(team["totals"]["members_count"]),
+                    "Keys": str(team["totals"]["keys"]),
+                    "Clicks": str(team["totals"]["clicks"]),
+                    "Scrolls": str(team["totals"]["scrolls"]),
+                    "DistanceInMiles": str(team["totals"]["distance_miles"]),
+                    "DownloadMB": team["totals"]["download_mb"],
+                    "UploadMB": team["totals"]["upload_mb"],
+                    "UptimeSeconds": str(team["totals"]["uptime_seconds"]),
+                    "Description": team["description"],
+                    "DateFormed": team["date_formed"][:19].replace("T", " "),
+                    "Ranks": {
+                        "Keys": str(team["ranks"]["keys"]),
+                        "Clicks": str(team["ranks"]["clicks"]),
+                        "Download": str(team["ranks"]["download"]),
+                        "Upload": str(team["ranks"]["upload"]),
+                        "Uptime": str(team["ranks"]["uptime"]),
+                        "Scrolls": str(team["ranks"]["scrolls"]),
+                        "Distance": str(team["ranks"]["distance"]),
+                    }
+                }
+
+            # Add last pulse information if available
+            if "last_pulse" in user_data and user_data["last_pulse"]:
+                # Convert ISO datetime to Unix timestamp
+                import datetime as dt
+                converted_data["LastPulseUnixTimestamp"] = str(int(dt.datetime.fromisoformat(user_data["last_pulse_date"].replace("Z", "+00:00")).timestamp()))
+
+            return converted_data
+
+        except Exception as ex:
+            _LOGGER.error(f"Error converting new API format: {ex}")
+            return False
+
+    def _format_bytes(self, bytes_value):
+        """Format bytes into human readable format."""
+        for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
+            if bytes_value < 1024.0:
+                return f"{bytes_value:.1f} {unit}"
+            bytes_value /= 1024.0
+        return f"{bytes_value:.1f} PB"
+
+    def _format_uptime_short(self, seconds):
+        """Format uptime in short format."""
+        years = seconds // 31536000  # 365 * 24 * 60 * 60
+        seconds %= 31536000
+        weeks = seconds // 604800    # 7 * 24 * 60 * 60
+        seconds %= 604800
+        days = seconds // 86400      # 24 * 60 * 60
+        seconds %= 86400
+        hours = seconds // 3600      # 60 * 60
+        seconds %= 3600
+        minutes = seconds // 60
+
+        parts = []
+        if years > 0:
+            parts.append(f"{years}y")
+        if weeks > 0:
+            parts.append(f"{weeks}w")
+        if days > 0:
+            parts.append(f"{days}d")
+        if hours > 0:
+            parts.append(f"{hours}h")
+        if minutes > 0:
+            parts.append(f"{minutes}m")
+
+        # Show at least minutes if everything else is 0
+        if not parts:
+            parts.append("0m")
+
+        return " ".join(parts)
+
+    def _format_uptime_long(self, seconds):
+        """Format uptime in long format."""
+        years = seconds // 31536000  # 365 * 24 * 60 * 60
+        seconds %= 31536000
+        weeks = seconds // 604800    # 7 * 24 * 60 * 60
+        seconds %= 604800
+        days = seconds // 86400      # 24 * 60 * 60
+        seconds %= 86400
+        hours = seconds // 3600      # 60 * 60
+        seconds %= 3600
+        minutes = seconds // 60
+        secs = seconds % 60
+
+        parts = []
+        if years > 0:
+            parts.append(f"{years} year{'s' if years != 1 else ''}")
+        if weeks > 0:
+            parts.append(f"{weeks} week{'s' if weeks != 1 else ''}")
+        if days > 0:
+            parts.append(f"{days} day{'s' if days != 1 else ''}")
+        if hours > 0:
+            parts.append(f"{hours} hour{'s' if hours != 1 else ''}")
+        if minutes > 0:
+            parts.append(f"{minutes} minute{'s' if minutes != 1 else ''}")
+        if secs > 0:
+            parts.append(f"{secs} second{'s' if secs != 1 else ''}")
+
+        # Show at least 0 seconds if everything else is 0
+        if not parts:
+            parts.append("0 seconds")
+
+        return ", ".join(parts)
 
     def _request_update_client(self):
         """Request update from WhatPulse client API."""
@@ -255,7 +426,7 @@ class WhatPulseSensor(SensorEntity):
         data = self._api._update()
 
         # Check if this is a rank sensor
-        is_rank = SENSOR_TYPES[self._sensor_type].get("is_rank", False)
+        is_rank = self._sensor_type.startswith("Rank")
 
         # Try to get data from client API first if available and applicable
         if "client" in data and self._client_path:
@@ -270,7 +441,7 @@ class WhatPulseSensor(SensorEntity):
                 if self._client_path and self._client_path[0] == "realtime":
                     return
 
-        # Fall back to public API data if available and no client data or realtime
+        # Fall back to public API data if available
         if "public" in data:
             public_data = data["public"]
 
@@ -279,6 +450,7 @@ class WhatPulseSensor(SensorEntity):
                 if "Ranks" in public_data and self._rank_key in public_data["Ranks"]:
                     self._state = public_data["Ranks"][self._rank_key]
                     self._attributes["data_source"] = "public"
+                    self._attributes["rank"] = self._state  # Set rank attribute for rank sensors
                 return
 
             # Update state if no client data or not a client-specific sensor


### PR DESCRIPTION
👋 I'm back with an API refactor from the old WhatPulse public API to the new public API that was released a few months ago. We'd like people to start using the new API, so I'm migrating connectors like this over. 

I also submitted a PR to home-assistant/brands to add an icon for WhatPulse, so hopefully we get an icon in HA soon. 🤞

BREAKING CHANGES:
- Public API now requires Bearer token authentication
- API endpoint changed from api.whatpulse.org to whatpulse.org/api/v1
- Users need to add `api_token` to configuration.yaml (see README for details)

Other changes:
- Added _convert_new_api_format() for new API structure & backward compatibility
- Added formatting function for uptime & network conversions
- Added Bearer token authentication to API requests